### PR TITLE
Add precise & xenial & bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
+  - os: linux
+    dist: xenial 
+    sudo: required
   - os: osx
   allow_failures:
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ matrix:
     dist: trusty
     sudo: required
   - os: linux
-    dist: xenial 
+    dist: xenial
+    sudo: required
+  - os: linux
+    dist: bionic
     sudo: required
   - os: osx
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 TARGET := main
 
 OS := $(shell uname -s)
+VERSION := $(shell lsb_release -rs 2> /dev/null)
 LATEXMK := $(shell command -v latexmk 2> /dev/null)
 LATEXMK_OPTION := -time -recorder -rules
 LATEXMK_EXEC := latexmk $(LATEXMK_OPTION)
@@ -38,7 +39,11 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
+ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
+else
+	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk
+endif
 endif
 ifeq ($(OS), Darwin)
 	brew tap caskroom/cask && brew cask install -v mactex && sudo tlmgr update --self --all

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
-ifeq ($(VERSION), 14.04)
+ifeq ($(VERSION), 12.04)
+	sudo apt-get install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
+else ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 else
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
-ifeq ($(VERSION), 12.04)
+ifeq ($(VERSION), )
+	$(error lsb-release is not installed)
+else ifeq ($(VERSION), 12.04)
 	sudo apt-get install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 else ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ else ifeq ($(VERSION), 12.04)
 else ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 else
-	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk
+	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra texlive-pictures xdvik-ja gv latexmk
 endif
 endif
 ifeq ($(OS), Darwin)

--- a/README.md
+++ b/README.md
@@ -2,18 +2,9 @@
 
 Latex template for Robotics Symposia
 
-### 1. Prerequisities
+### 1. Edit LaTeX files
 
-```bash
-# only for ubuntu 12.04
-$ sudo apt-add-repository ppa:texlive-backports/ppa
-$ sudo apt-get update
-$ sudo apt-get install lsb-release
-```
-
-### 2. Edit LaTeX files
-
-### 3. Make pdf
+### 2. Make pdf
 
 ```bash
 $ make

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Latex template for Robotics Symposia
 # only for ubuntu 12.04
 $ sudo apt-add-repository ppa:texlive-backports/ppa
 $ sudo apt-get update
+$ sudo apt-get install lsb-release
 ```
 
 ### 2. Edit LaTeX files


### PR DESCRIPTION
https://github.com/jsk-report-template/si-template/pull/3 + https://github.com/jsk-report-template/si-template/pull/4 + https://github.com/jsk-report-template/si-template/pull/5
### Other fixes
- Install `texlive-pictures` on xenial and bionic
  - This is because [this repo uses epic](https://github.com/jsk-report-template/robosym-template/blob/b56f070a4873ddd4014ca33f5596bcc5d663e717/main.tex#L14), which is included in `texlive-pictures`:
    https://ubuntu.pkgs.org/18.04/ubuntu-universe-amd64/texlive-pictures_2017.20180305-1_all.deb.html